### PR TITLE
Fix usage in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 	},
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
Fixes the error `Module not found: Error: Default condition should be last one` when importing `smol-toml` in a webpack project.