### PR TITLE
Add basic tester Github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
           - macos-latest
           - windows-latest
         node-version:
-          - 14
           - 16
           - 18
           - 20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Quality Check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node-version:
+          - 14
+          - 16
+          - 18
+          - 20
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: Quality Check
 on:
   push:
     branches:
-      - main
+      - mistress
   pull_request:
     branches:
-      - main
+      - mistress
 
 jobs:
   test:


### PR DESCRIPTION
Relates to https://github.com/squirrelchat/smol-toml/issues/7

As I investigated the test failure of my package with Windows, I wanted to confirm I didn't inherit the failure from this dependency (spoiler: this package tests just fine under Windows). Since this workflow was largely just a matter of copying and pasting and it's definitely better than nothing, why not share it? :)

Currently, it installs the (dev) dependencies of the package and runs the tests on all configurations of 3 OSes (latest Windows, latest MacOS, latest Ubuntu) and the 3 latest stable Node versions (v16 is the latest that works with this package and/or the dev dependencies). The tests pass on all these configurations.