### PR TITLE
Remove pnpm from engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
 	"author": "Cynthia <cyyynthia@borkenware.com>",
 	"license": "BSD-3-Clause",
 	"engines": {
-		"node": ">= 18",
-		"pnpm": ">= 9"
+		"node": ">= 18"
 	},
 	"scripts": {
 		"build": "tsc",


### PR DESCRIPTION
Fixes #22

Happy to pin pnpm via another means, but CI already appears to hardcode v9.