### PR TITLE
Use more detailed TOML types

### DIFF
--- a/run-toml-test.bash
+++ b/run-toml-test.bash
@@ -7,6 +7,7 @@ skip_decode=(
 
 	# Certain invalid UTF-8 codepoints are not rejected
 	-skip='invalid/encoding/bad-codepoint'
+	-skip='invalid/string/bad-uni-esc-6'
 	-skip='invalid/string/bad-uni-esc-06'
 	-skip='invalid/string/bad-uni-esc-ml-6'
 

--- a/run-toml-test.bash
+++ b/run-toml-test.bash
@@ -7,7 +7,8 @@ skip_decode=(
 
 	# Certain invalid UTF-8 codepoints are not rejected
 	-skip='invalid/encoding/bad-codepoint'
-	-skip='invalid/string/bad-uni-esc-6'
+	-skip='invalid/string/bad-uni-esc-06'
+	-skip='invalid/string/bad-uni-esc-ml-6'
 
 	# JS* doesn't reject invalid dates, but interprets extra days such as "Feb 30 2023" as "Feb 28 2023 +2d" gracefully.
 	#

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -28,7 +28,7 @@
 
 import { parseString, parseValue } from './primitive.js'
 import { parseArray, parseInlineTable } from './struct.js'
-import { type TomlPrimitive, indexOfNewline, skipVoid, skipUntil, skipComment, getStringEnd } from './util.js'
+import { indexOfNewline, skipVoid, skipUntil, skipComment, getStringEnd, type TOMLValue } from './util.js'
 import { TomlError } from './error.js'
 
 function sliceAndTrimEndOf (str: string, startPtr: number, endPtr: number, allowNewLines?: boolean): [ string, number ] {
@@ -57,7 +57,7 @@ function sliceAndTrimEndOf (str: string, startPtr: number, endPtr: number, allow
 	return [ trimmed, commentIdx ]
 }
 
-export function extractValue (str: string, ptr: number, end?: string | undefined, depth: number = -1): [ TomlPrimitive, number ] {
+export function extractValue (str: string, ptr: number, end?: string | undefined, depth: number = -1): [ TOMLValue, number ] {
 	if (depth === 0) {
 		throw new TomlError('document contains excessively nested structures. aborting.', {
 			toml: str,

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -28,7 +28,7 @@
 
 import { parseString, parseValue } from './primitive.js'
 import { parseArray, parseInlineTable } from './struct.js'
-import { indexOfNewline, skipVoid, skipUntil, skipComment, getStringEnd, type TOMLValue } from './util.js'
+import { indexOfNewline, skipVoid, skipUntil, skipComment, getStringEnd, type TomlValue } from './util.js'
 import { TomlError } from './error.js'
 
 function sliceAndTrimEndOf (str: string, startPtr: number, endPtr: number, allowNewLines?: boolean): [ string, number ] {
@@ -57,7 +57,7 @@ function sliceAndTrimEndOf (str: string, startPtr: number, endPtr: number, allow
 	return [ trimmed, commentIdx ]
 }
 
-export function extractValue (str: string, ptr: number, end?: string | undefined, depth: number = -1): [ TOMLValue, number ] {
+export function extractValue (str: string, ptr: number, end?: string | undefined, depth: number = -1): [ TomlValue, number ] {
 	if (depth === 0) {
 		throw new TomlError('document contains excessively nested structures. aborting.', {
 			toml: str,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ import { stringify } from './stringify.js'
 import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type { TOMLValue, TOMLTable, TOMLValue as TomlPrimitive } from './util.js'
+export type { TomlValue, TomlTable, TomlValue as TomlPrimitive } from './util.js'
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { stringify } from './stringify.js'
 import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type { TomlValue, TomlTable, TomlValue as TomlPrimitive } from './util.js'
+export type { TomlValue, TomlTable } from './util.js'
+export type { TomlValue as TomlPrimitive } from './util.js' // deprecated, to be removed in v2.x
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ import { stringify } from './stringify.js'
 import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type { TomlPrimitive } from './util.js'
+export type { TOMLValue, TOMLValue as TomlPrimitive } from './util.js'
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
 export type { TomlValue, TomlTable } from './util.js'
-export type { TomlValue as TomlPrimitive } from './util.js' // deprecated, to be removed in v2.x
+/** @deprecated to be removed in v2.x */
+export type { TomlValue as TomlPrimitive } from './util.js'
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,10 @@ import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
 export type { TomlValue, TomlTable } from './util.js'
-/** @deprecated to be removed in v2.x */
-export type { TomlValue as TomlPrimitive } from './util.js'
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }
+
+export type {
+	/** @deprecated use TomlValue instead */
+	TomlValue as TomlPrimitive
+} from './util.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ import { stringify } from './stringify.js'
 import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type { TOMLValue, TOMLValue as TomlPrimitive } from './util.js'
+export type { TOMLValue, TOMLTable, TOMLValue as TomlPrimitive } from './util.js'
 export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,16 +28,16 @@
 
 import { parseKey } from './struct.js'
 import { extractValue } from './extract.js'
-import { skipVoid, type TOMLTable } from './util.js'
+import { skipVoid, type TomlTable } from './util.js'
 import { TomlError } from './error.js'
 
 const enum Type { DOTTED, EXPLICIT, ARRAY, ARRAY_DOTTED }
 
 type MetaState = { t: Type, d: boolean, i: number, c: MetaRecord }
 type MetaRecord = { [k: string]: MetaState }
-type PeekResult = [ string, TOMLTable, MetaRecord ] | null
+type PeekResult = [ string, TomlTable, MetaRecord ] | null
 
-function peekTable (key: string[], table: TOMLTable, meta: MetaRecord, type: Type): PeekResult {
+function peekTable (key: string[], table: TomlTable, meta: MetaRecord, type: Type): PeekResult {
 	let t: any = table
 	let m = meta
 	let k: string
@@ -113,7 +113,7 @@ function peekTable (key: string[], table: TOMLTable, meta: MetaRecord, type: Typ
 	return [ k!, t, state.c ]
 }
 
-export function parse (toml: string, opts?: { maxDepth: number }): TOMLTable {
+export function parse (toml: string, opts?: { maxDepth: number }): TomlTable {
 	let maxDepth = opts?.maxDepth ?? 1000
 	let res = {}
 	let meta = {}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,16 +28,16 @@
 
 import { parseKey } from './struct.js'
 import { extractValue } from './extract.js'
-import { type TomlPrimitive, skipVoid } from './util.js'
+import { skipVoid, type TOMLTable } from './util.js'
 import { TomlError } from './error.js'
 
 const enum Type { DOTTED, EXPLICIT, ARRAY, ARRAY_DOTTED }
 
 type MetaState = { t: Type, d: boolean, i: number, c: MetaRecord }
 type MetaRecord = { [k: string]: MetaState }
-type PeekResult = [ string, Record<string, TomlPrimitive>, MetaRecord ] | null
+type PeekResult = [ string, TOMLTable, MetaRecord ] | null
 
-function peekTable (key: string[], table: Record<string, TomlPrimitive>, meta: MetaRecord, type: Type): PeekResult {
+function peekTable (key: string[], table: TOMLTable, meta: MetaRecord, type: Type): PeekResult {
 	let t: any = table
 	let m = meta
 	let k: string
@@ -113,7 +113,7 @@ function peekTable (key: string[], table: Record<string, TomlPrimitive>, meta: M
 	return [ k!, t, state.c ]
 }
 
-export function parse (toml: string, opts?: { maxDepth: number }): Record<string, TomlPrimitive> {
+export function parse (toml: string, opts?: { maxDepth: number }): TOMLTable {
 	let maxDepth = opts?.maxDepth ?? 1000
 	let res = {}
 	let meta = {}

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -28,7 +28,7 @@
 
 import { parseString } from './primitive.js'
 import { extractValue } from './extract.js'
-import { skipComment, indexOfNewline, getStringEnd, skipVoid, type TOMLTable, type TOMLArray, type TOMLValue } from './util.js'
+import { skipComment, indexOfNewline, getStringEnd, skipVoid, type TomlTable, type TomlArray, type TomlValue } from './util.js'
 import { TomlError } from './error.js'
 
 let KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/
@@ -116,8 +116,8 @@ export function parseKey (str: string, ptr: number, end = '='): [ string[], numb
 	return [ parsed, skipVoid(str, endPtr + 1, true, true) ]
 }
 
-export function parseInlineTable (str: string, ptr: number, depth: number = -1): [ TOMLTable, number ] {
-	let res: TOMLTable = {}
+export function parseInlineTable (str: string, ptr: number, depth: number = -1): [ TomlTable, number ] {
+	let res: TomlTable = {}
 	let seen = new Set()
 	let c: string
 	let comma = 0
@@ -194,8 +194,8 @@ export function parseInlineTable (str: string, ptr: number, depth: number = -1):
 	return [ res, ptr ]
 }
 
-export function parseArray (str: string, ptr: number, depth: number = -1): [ TOMLArray, number ] {
-	let res: TOMLValue[] = []
+export function parseArray (str: string, ptr: number, depth: number = -1): [ TomlArray, number ] {
+	let res: TomlValue[] = []
 	let c
 
 	ptr++

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -28,7 +28,7 @@
 
 import { parseString } from './primitive.js'
 import { extractValue } from './extract.js'
-import { skipComment, indexOfNewline, getStringEnd, skipVoid, type TomlTable, type TomlArray, type TomlValue } from './util.js'
+import { skipComment, indexOfNewline, getStringEnd, skipVoid, type TomlTable, type TomlValue } from './util.js'
 import { TomlError } from './error.js'
 
 let KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/
@@ -194,7 +194,7 @@ export function parseInlineTable (str: string, ptr: number, depth: number = -1):
 	return [ res, ptr ]
 }
 
-export function parseArray (str: string, ptr: number, depth: number = -1): [ TomlArray, number ] {
+export function parseArray (str: string, ptr: number, depth: number = -1): [ TomlValue[], number ] {
 	let res: TomlValue[] = []
 	let c
 

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -28,7 +28,7 @@
 
 import { parseString } from './primitive.js'
 import { extractValue } from './extract.js'
-import { type TomlPrimitive, skipComment, indexOfNewline, getStringEnd, skipVoid } from './util.js'
+import { skipComment, indexOfNewline, getStringEnd, skipVoid, type TOMLTable, type TOMLArray, type TOMLValue } from './util.js'
 import { TomlError } from './error.js'
 
 let KEY_PART_RE = /^[a-zA-Z0-9-_]+[ \t]*$/
@@ -116,8 +116,8 @@ export function parseKey (str: string, ptr: number, end = '='): [ string[], numb
 	return [ parsed, skipVoid(str, endPtr + 1, true, true) ]
 }
 
-export function parseInlineTable (str: string, ptr: number, depth: number = -1): [ Record<string, TomlPrimitive>, number ] {
-	let res: Record<string, TomlPrimitive> = {}
+export function parseInlineTable (str: string, ptr: number, depth: number = -1): [ TOMLTable, number ] {
+	let res: TOMLTable = {}
 	let seen = new Set()
 	let c: string
 	let comma = 0
@@ -194,8 +194,8 @@ export function parseInlineTable (str: string, ptr: number, depth: number = -1):
 	return [ res, ptr ]
 }
 
-export function parseArray (str: string, ptr: number, depth: number = -1): [ TomlPrimitive[], number ] {
-	let res: TomlPrimitive[] = []
+export function parseArray (str: string, ptr: number, depth: number = -1): [ TOMLArray, number ] {
+	let res: TOMLValue[] = []
 	let c
 
 	ptr++

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,8 +31,7 @@ import { TomlError } from './error.js'
 
 export type TomlPrimitive = string | number | boolean | TomlDate
 export type TomlTable = { [Key in string]: TomlValue } & { [Key in string]?: TomlValue | undefined }
-export type TomlArray = TomlValue[] | readonly TomlValue[]
-export type TomlValue = TomlPrimitive | TomlArray | TomlTable
+export type TomlValue = TomlPrimitive | TomlValue[] | TomlTable
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {
 	let idx = str.indexOf('\n', start)

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ import type { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
 export type TomlPrimitive = string | number | boolean | TomlDate
-export type TomlTable = { [Key in string]: TomlValue }
+export type TomlTable = { [key: string]: TomlValue }
 export type TomlValue = TomlPrimitive | TomlValue[] | TomlTable
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ import type { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
 export type TomlPrimitive = string | number | boolean | TomlDate
-export type TomlTable = { [Key in string]: TomlValue } & { [Key in string]?: TomlValue | undefined }
+export type TomlTable = { [Key in string]: TomlValue }
 export type TomlValue = TomlPrimitive | TomlValue[] | TomlTable
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,13 +29,10 @@
 import type { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type TomlPrimitive =
-	| string
-	| number
-	| boolean
-	| TomlDate
-	| { [key: string]: TomlPrimitive }
-	| TomlPrimitive[]
+export type TOMLTable = {[Key in string]: TOMLValue} & {[Key in string]?: TOMLValue|undefined};
+export type TOMLArray = TOMLValue[] | readonly TOMLValue[];
+export type TOMLPrimitive = string | number | boolean | TomlDate;
+export type TOMLValue = TOMLPrimitive | TOMLArray | TOMLTable;
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {
 	let idx = str.indexOf('\n', start)

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,10 +29,10 @@
 import type { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type TOMLTable = {[Key in string]: TOMLValue} & {[Key in string]?: TOMLValue|undefined};
-export type TOMLArray = TOMLValue[] | readonly TOMLValue[];
-export type TOMLPrimitive = string | number | boolean | TomlDate;
-export type TOMLValue = TOMLPrimitive | TOMLArray | TOMLTable;
+export type TomlPrimitive = string | number | boolean | TomlDate;
+export type TomlTable = {[Key in string]: TomlValue} & {[Key in string]?: TomlValue|undefined};
+export type TomlArray = TomlValue[] | readonly TomlValue[];
+export type TomlValue = TomlPrimitive | TomlArray | TomlTable;
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {
 	let idx = str.indexOf('\n', start)

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,10 +29,10 @@
 import type { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
-export type TomlPrimitive = string | number | boolean | TomlDate;
-export type TomlTable = {[Key in string]: TomlValue} & {[Key in string]?: TomlValue|undefined};
-export type TomlArray = TomlValue[] | readonly TomlValue[];
-export type TomlValue = TomlPrimitive | TomlArray | TomlTable;
+export type TomlPrimitive = string | number | boolean | TomlDate
+export type TomlTable = { [Key in string]: TomlValue } & { [Key in string]?: TomlValue | undefined }
+export type TomlArray = TomlValue[] | readonly TomlValue[]
+export type TomlValue = TomlPrimitive | TomlArray | TomlTable
 
 export function indexOfNewline (str: string, start = 0, end = str.length) {
 	let idx = str.indexOf('\n', start)


### PR DESCRIPTION
The types themselves are inspired from type-fest's json types : https://github.com/sindresorhus/type-fest/blob/main/source/json-value.d.ts

I kept the export under the original name for compatibility, but also exposed it under the new name. I think all 4 new types could be exposed, but that would be at the risk of name ambiguity. Maybe at the next major version hike ?