### PR TITLE
Serialize all numbers as floats

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -51,7 +51,7 @@ function formatString (s: string) {
 	return JSON.stringify(s).replace(/\x7f/g, '\\u007f')
 }
 
-function stringifyValue (val: any, type: ExtendedType, depth: number) {
+function stringifyValue(val: any, type: ExtendedType, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
 		throw new Error("Could not stringify the object: maximum object depth exceeded")
 	}
@@ -60,6 +60,7 @@ function stringifyValue (val: any, type: ExtendedType, depth: number) {
 		if (isNaN(val)) return 'nan'
 		if (val === Infinity) return 'inf'
 		if (val === -Infinity) return '-inf'
+		if (numberAsFloat) return val.toExponential()
 		return val.toString()
 	}
 
@@ -80,15 +81,15 @@ function stringifyValue (val: any, type: ExtendedType, depth: number) {
 	}
 
 	if (type === 'object') {
-		return stringifyInlineTable(val, depth)
+		return stringifyInlineTable(val, depth, numberAsFloat)
 	}
 
 	if (type === 'array') {
-		return stringifyArray(val, depth)
+		return stringifyArray(val, depth, numberAsFloat)
 	}
 }
 
-function stringifyInlineTable (obj: any, depth: number) {
+function stringifyInlineTable(obj: any, depth: number, numberAsFloat: boolean) {
 	let keys = Object.keys(obj)
 	if (keys.length === 0) return '{}'
 
@@ -99,13 +100,13 @@ function stringifyInlineTable (obj: any, depth: number) {
 
 		res += BARE_KEY.test(k) ? k : formatString(k)
 		res += ' = '
-		res += stringifyValue(obj[k], extendedTypeOf(obj[k]), depth - 1)
+		res += stringifyValue(obj[k], extendedTypeOf(obj[k]), depth - 1, numberAsFloat)
 	}
 
 	return res + ' }'
 }
 
-function stringifyArray (array: any[], depth: number) {
+function stringifyArray(array: any[], depth: number, numberAsFloat: boolean) {
 	if (array.length === 0) return '[]'
 
 	let res = '[ '
@@ -115,13 +116,13 @@ function stringifyArray (array: any[], depth: number) {
 			throw new TypeError('arrays cannot contain null or undefined values')
 		}
 
-		res += stringifyValue(array[i], extendedTypeOf(array[i]), depth - 1)
+		res += stringifyValue(array[i], extendedTypeOf(array[i]), depth - 1, numberAsFloat)
 	}
 
 	return res + ' ]'
 }
 
-function stringifyArrayTable (array: any[], key: string, depth: number) {
+function stringifyArrayTable(array: any[], key: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
 		throw new Error("Could not stringify the object: maximum object depth exceeded")
 	}
@@ -129,14 +130,14 @@ function stringifyArrayTable (array: any[], key: string, depth: number) {
 	let res = ''
 	for (let i = 0; i < array.length; i++) {
 		res += `[[${key}]]\n`
-		res += stringifyTable(array[i], key, depth)
+		res += stringifyTable(array[i], key, depth, numberAsFloat)
 		res += '\n\n'
 	}
 
 	return res
 }
 
-function stringifyTable (obj: any, prefix: string, depth: number) {
+function stringifyTable(obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
 		throw new Error("Could not stringify the object: maximum object depth exceeded")
 	}
@@ -156,16 +157,16 @@ function stringifyTable (obj: any, prefix: string, depth: number) {
 			let key = BARE_KEY.test(k) ? k : formatString(k)
 
 			if (type === 'array' && isArrayOfTables(obj[k])) {
-				tables += stringifyArrayTable(obj[k], prefix ? `${prefix}.${key}` : key, depth - 1)
+				tables += stringifyArrayTable(obj[k], prefix ? `${prefix}.${key}` : key, depth - 1, numberAsFloat)
 			} else if (type === 'object') {
 				let tblKey = prefix ? `${prefix}.${key}` : key
 				tables += `[${tblKey}]\n`
-				tables += stringifyTable(obj[k], tblKey, depth - 1)
+				tables += stringifyTable(obj[k], tblKey, depth - 1, numberAsFloat)
 				tables += '\n\n'
 			} else {
 				preamble += key
 				preamble += ' = '
-				preamble += stringifyValue(obj[k], type, depth)
+				preamble += stringifyValue(obj[k], type, depth, numberAsFloat)
 				preamble += '\n'
 			}
 		}
@@ -174,11 +175,13 @@ function stringifyTable (obj: any, prefix: string, depth: number) {
 	return `${preamble}\n${tables}`.trim()
 }
 
-export function stringify (obj: any, opts?: { maxDepth?: number }) {
+export function stringify(
+	obj: any,
+	{ maxDepth = 1000, numberAsFloat = false }: { maxDepth?: number, numberAsFloat?: boolean } = {}
+) {
 	if (extendedTypeOf(obj) !== 'object') {
 		throw new TypeError('stringify can only be called with an object')
 	}
 
-	let maxDepth = opts?.maxDepth ?? 1000
-	return stringifyTable(obj, '', maxDepth)
+	return stringifyTable(obj, '', maxDepth, numberAsFloat)
 }

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -51,9 +51,9 @@ function formatString (s: string) {
 	return JSON.stringify(s).replace(/\x7f/g, '\\u007f')
 }
 
-function stringifyValue(val: any, type: ExtendedType, depth: number, numberAsFloat: boolean) {
+function stringifyValue (val: any, type: ExtendedType, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
-		throw new Error("Could not stringify the object: maximum object depth exceeded")
+		throw new Error('Could not stringify the object: maximum object depth exceeded')
 	}
 
 	if (type === 'number') {
@@ -89,7 +89,7 @@ function stringifyValue(val: any, type: ExtendedType, depth: number, numberAsFlo
 	}
 }
 
-function stringifyInlineTable(obj: any, depth: number, numberAsFloat: boolean) {
+function stringifyInlineTable (obj: any, depth: number, numberAsFloat: boolean) {
 	let keys = Object.keys(obj)
 	if (keys.length === 0) return '{}'
 
@@ -106,7 +106,7 @@ function stringifyInlineTable(obj: any, depth: number, numberAsFloat: boolean) {
 	return res + ' }'
 }
 
-function stringifyArray(array: any[], depth: number, numberAsFloat: boolean) {
+function stringifyArray (array: any[], depth: number, numberAsFloat: boolean) {
 	if (array.length === 0) return '[]'
 
 	let res = '[ '
@@ -122,9 +122,9 @@ function stringifyArray(array: any[], depth: number, numberAsFloat: boolean) {
 	return res + ' ]'
 }
 
-function stringifyArrayTable(array: any[], key: string, depth: number, numberAsFloat: boolean) {
+function stringifyArrayTable (array: any[], key: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
-		throw new Error("Could not stringify the object: maximum object depth exceeded")
+		throw new Error('Could not stringify the object: maximum object depth exceeded')
 	}
 
 	let res = ''
@@ -137,9 +137,9 @@ function stringifyArrayTable(array: any[], key: string, depth: number, numberAsF
 	return res
 }
 
-function stringifyTable(obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
+function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
-		throw new Error("Could not stringify the object: maximum object depth exceeded")
+		throw new Error('Could not stringify the object: maximum object depth exceeded')
 	}
 
 	let preamble = ''
@@ -175,9 +175,9 @@ function stringifyTable(obj: any, prefix: string, depth: number, numberAsFloat: 
 	return `${preamble}\n${tables}`.trim()
 }
 
-export function stringify(
+export function stringify (
 	obj: any,
-	{ maxDepth = 1000, numberAsFloat = false }: { maxDepth?: number, numberAsFloat?: boolean } = {}
+	{ maxDepth = 1000, numberAsFloat = false }: { maxDepth?: number, numberAsFloat?: boolean } = {},
 ) {
 	if (extendedTypeOf(obj) !== 'object') {
 		throw new TypeError('stringify can only be called with an object')

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -60,7 +60,7 @@ function stringifyValue(val: any, type: ExtendedType, depth: number, numberAsFlo
 		if (isNaN(val)) return 'nan'
 		if (val === Infinity) return 'inf'
 		if (val === -Infinity) return '-inf'
-		if (numberAsFloat) return val.toExponential()
+		if (numberAsFloat && Number.isInteger(val)) return val.toFixed(1)
 		return val.toString()
 	}
 

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -59,7 +59,7 @@ a = 100
 
 it('stringifies integers as floats', () => {
 	const expected = `
-a = 1e+2
+a = 100.0
 `.trim()
 
 	expect(stringify({ a: 100 }, { numberAsFloat: true }).trim()).toBe(expected)
@@ -88,6 +88,7 @@ nan = nan
 	}
 
 	expect(stringify(obj).trim()).toBe(expected)
+	expect(stringify(obj, { numberAsFloat: true }).trim()).toBe(expected)
 })
 
 it('stringifies dates properly', () => {

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -65,6 +65,15 @@ a = 1e+2
 	expect(stringify({ a: 100 }, { numberAsFloat: true }).trim()).toBe(expected)
 })
 
+it('stringifies floats as floats', () => {
+	const expected = `
+a = 100.146
+`.trim()
+
+	expect(stringify({ a: 100.146 }).trim()).toBe(expected)
+	expect(stringify({ a: 100.146 }, { numberAsFloat: true }).trim()).toBe(expected)
+})
+
 it('stringifies special float values', () => {
 	const expected = `
 inf = inf

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -49,6 +49,22 @@ a = 100
 	expect(stringify({ a: 100n }).trim()).toBe(expected)
 })
 
+it('stringifies integers as integers', () => {
+	const expected = `
+a = 100
+`.trim()
+
+	expect(stringify({ a: 100 }).trim()).toBe(expected)
+})
+
+it('stringifies integers as floats', () => {
+	const expected = `
+a = 1e+2
+`.trim()
+
+	expect(stringify({ a: 100 }, { numberAsFloat: true }).trim()).toBe(expected)
+})
+
 it('stringifies special float values', () => {
 	const expected = `
 inf = inf

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { it, expect } from 'vitest'
+import { expect, it } from 'vitest'
 import { stringify } from '../src/stringify.js'
 import { TomlDate } from '../src/date.js'
 
@@ -198,7 +198,11 @@ a = 2
 a = 3
 `.trim()
 
-	expect(stringify({ 'test-key123_': { a: 1 }, 'test key 123': { a: 2 }, 'testkey@': { a: 3 } }).trim()).toBe(expected)
+	expect(stringify({
+		'test-key123_': { a: 1 },
+		'test key 123': { a: 2 },
+		'testkey@': { a: 3 },
+	}).trim()).toBe(expected)
 })
 
 it('does not produce invalid strings', () => {
@@ -226,7 +230,7 @@ it('ignores null and undefined on objects', () => {
 	const testObj = {
 		a: null,
 		b: void 0,
-		c: 1
+		c: 1,
 	}
 
 	expect(stringify(testObj).trim()).toBe('c = 1')
@@ -234,8 +238,8 @@ it('ignores null and undefined on objects', () => {
 
 
 it('rejects null and undefined in arrays', () => {
-	expect(() => stringify({ a: [ 1, null, 2 ]})).toThrow(TypeError)
-	expect(() => stringify({ a: [ 1, void 0, 2 ]})).toThrow(TypeError)
+	expect(() => stringify({ a: [ 1, null, 2 ] })).toThrow(TypeError)
+	expect(() => stringify({ a: [ 1, void 0, 2 ] })).toThrow(TypeError)
 })
 
 it('rejects functions and symbols', () => {


### PR DESCRIPTION
As mentioned in #41.
I'm a slight opponent to serializing to TOML in general, so I don't have a beef in this game. But I think having a type-stable serialize-deserialize cycle can be a feature, and for this, this is the counterpart of the "integers_as_bigint" parsing option.

An alternate solution that's quicker to compute and save a whopping 20 characters in the script (that's smol) can be found in earlier commits : it uses exponential notation, and exponential is TOML-float.
I believe TOML should remain human-oriented, and I don't find it obvious at all that exponentials are not integers, and I think using a point to denote floatability is more clear, so this implementation uses a single digit after the decimal point.