### PR TITLE
Simplify nested tables

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -137,6 +137,38 @@ function stringifyArrayTable (array: any[], key: string, depth: number, numberAs
 	return res
 }
 
+/** 
+ * If all children of a table are themselves tables or arrays we don't need to include the table key at this level.
+ * Otherwise, we'd end up with redundant output like this:
+ * 
+ *   [key]
+ *   [[key.array]]
+ *   key = "value"
+ * 
+ *   [key.table]
+ *   key = "value"
+ * 
+ * when that can be more simply expressed as just
+ * 
+ *   [[key.array]]
+ *   key = "value"
+ * 
+ *   [key.table]
+ *   key = "value"
+ * 
+ */
+function needsTableKey(obj: any): boolean {
+	return Object.keys(obj).length === 0 || !Object.keys(obj).every(
+		childKey => {
+			if(obj[childKey] !== null && obj[childKey] !== void 0) {
+				let childType = extendedTypeOf(obj[childKey]);
+				return childType === 'object' || (childType === 'array' && isArrayOfTables(obj[childKey]))
+			}
+			return false
+		}
+	)
+}
+
 function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
 		throw new Error('Could not stringify the object: maximum object depth exceeded')
@@ -160,9 +192,14 @@ function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat:
 				tables += stringifyArrayTable(obj[k], prefix ? `${prefix}.${key}` : key, depth - 1, numberAsFloat)
 			} else if (type === 'object') {
 				let tblKey = prefix ? `${prefix}.${key}` : key
-				tables += `[${tblKey}]\n`
-				tables += stringifyTable(obj[k], tblKey, depth - 1, numberAsFloat)
-				tables += '\n\n'
+				if (needsTableKey(obj[k])) {
+					tables += `[${tblKey}]\n`
+				}
+				const table = stringifyTable(obj[k], tblKey, depth - 1, numberAsFloat)
+				if(table !== "") {
+					tables += table
+					tables += '\n\n'
+				}
 			} else {
 				preamble += key
 				preamble += ' = '

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -130,46 +130,14 @@ function stringifyArrayTable (array: any[], key: string, depth: number, numberAs
 	let res = ''
 	for (let i = 0; i < array.length; i++) {
 		res += `[[${key}]]\n`
-		res += stringifyTable(array[i], key, depth, numberAsFloat)
+		res += stringifyTable(0, array[i], key, depth, numberAsFloat)
 		res += '\n'
 	}
 
 	return res
 }
 
-/** 
- * If all children of a table are themselves tables or arrays we don't need to include the table key at this level.
- * Otherwise, we'd end up with redundant output like this:
- * 
- *   [key]
- *   [[key.array]]
- *   key = "value"
- * 
- *   [key.table]
- *   key = "value"
- * 
- * when that can be more simply expressed as just
- * 
- *   [[key.array]]
- *   key = "value"
- * 
- *   [key.table]
- *   key = "value"
- * 
- */
-function needsTableKey(obj: any): boolean {
-	return Object.keys(obj).length === 0 || !Object.keys(obj).every(
-		childKey => {
-			if(obj[childKey] !== null && obj[childKey] !== void 0) {
-				let childType = extendedTypeOf(obj[childKey]);
-				return childType === 'object' || (childType === 'array' && isArrayOfTables(obj[childKey]))
-			}
-			return false
-		}
-	)
-}
-
-function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
+function stringifyTable (tableKey: string | 0, obj: any, prefix: string, depth: number, numberAsFloat: boolean) {
 	if (depth === 0) {
 		throw new Error('Could not stringify the object: maximum object depth exceeded')
 	}
@@ -192,14 +160,8 @@ function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat:
 				tables += stringifyArrayTable(obj[k], prefix ? `${prefix}.${key}` : key, depth - 1, numberAsFloat)
 			} else if (type === 'object') {
 				let tblKey = prefix ? `${prefix}.${key}` : key
-				if (needsTableKey(obj[k])) {
-					tables += `[${tblKey}]\n`
-				}
-				const table = stringifyTable(obj[k], tblKey, depth - 1, numberAsFloat)
-				if(table !== "") {
-					tables += table
-					tables += '\n'
-				}
+				let table = stringifyTable(tblKey, obj[k], tblKey, depth - 1, numberAsFloat)
+				if (table) tables += table + '\n'
 			} else {
 				preamble += key
 				preamble += ' = '
@@ -208,6 +170,9 @@ function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat:
 			}
 		}
 	}
+
+	if (tableKey && (preamble || !tables)) // Create table only if necessary
+		preamble = preamble ? `[${tableKey}]\n${preamble}` : `[${tableKey}]`
 
 	return preamble && tables
 		? `${preamble}\n${tables}`
@@ -222,5 +187,5 @@ export function stringify (
 		throw new TypeError('stringify can only be called with an object')
 	}
 
-	return stringifyTable(obj, '', maxDepth, numbersAsFloat)
+	return stringifyTable(0, obj, '', maxDepth, numbersAsFloat)
 }

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -131,7 +131,7 @@ function stringifyArrayTable (array: any[], key: string, depth: number, numberAs
 	for (let i = 0; i < array.length; i++) {
 		res += `[[${key}]]\n`
 		res += stringifyTable(array[i], key, depth, numberAsFloat)
-		res += '\n\n'
+		res += '\n'
 	}
 
 	return res
@@ -198,7 +198,7 @@ function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat:
 				const table = stringifyTable(obj[k], tblKey, depth - 1, numberAsFloat)
 				if(table !== "") {
 					tables += table
-					tables += '\n\n'
+					tables += '\n'
 				}
 			} else {
 				preamble += key
@@ -209,7 +209,9 @@ function stringifyTable (obj: any, prefix: string, depth: number, numberAsFloat:
 		}
 	}
 
-	return `${preamble}\n${tables}`.trim()
+	return preamble && tables
+		? `${preamble}\n${tables}`
+		: preamble || tables
 }
 
 export function stringify (

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -154,6 +154,37 @@ c = 2
 	expect(stringify({ a: { b: 1, c: 2 }, d: 3 }).trim()).toBe(expected)
 })
 
+it('stringifies nested tables and handles top-level keys', () => {
+	const expected = `
+d = 3
+
+[a.b]
+b = 1
+c = 2
+`.trim()
+
+	expect(stringify({ a: {b: { b: 1, c: 2 },  }, d: 3}).trim()).toBe(expected)
+})
+
+it("stringifies empty tables with no gaps", () => {
+	const expected = `
+[animal]
+[fruit.apple]
+[fruit.orange]
+`.trim();
+
+	expect(
+		stringify({
+			animal: {},
+			fruit: {
+				apple: {},
+				orange: {},
+			},
+		}).trim()
+	).toBe(expected);
+});
+
+
 it('stringifies tables contained in arrays', () => {
 	const expected = `
 a = [ 1, { b = 2, c = 3 }, 4 ]
@@ -175,6 +206,59 @@ c = 4
 
 	expect(stringify({ a: [ { b: 1, c: 2 }, { b: 3, c: 4 } ] }).trim()).toBe(expected)
 })
+
+it("stringifies nested arrays of tables", () => {
+	const expected = `
+[[a.b]]
+b = 1
+c = 2
+
+[[a.b]]
+b = 3
+c = 4
+`.trim();
+
+	expect(
+		stringify({
+			a: {
+				b: [
+					{ b: 1, c: 2 },
+					{ b: 3, c: 4 },
+				],
+			},
+		}).trim()
+	).toBe(expected);
+});
+
+it("stringifies nested arrays of tables with top level keys", () => {
+	const expected = `
+key = "hello"
+
+[a]
+key = "hello"
+
+[[a.b]]
+b = 1
+c = 2
+
+[[a.b]]
+b = 3
+c = 4
+`.trim();
+
+	expect(
+		stringify({
+			key: "hello",
+			a: {
+				key: "hello",
+				b: [
+					{ b: 1, c: 2 },
+					{ b: 3, c: 4 },
+				],
+			},
+		}).trim()
+	).toBe(expected);
+});
 
 it('does not produce invalid keys', () => {
 	const expected = `


### PR DESCRIPTION
As part of trying to migrate to `smol-toml` from `@iarna/toml` in [Cloudflare's Wrangler](https://github.com/cloudflare/workers-sdk), we've been running into some differences in how `smol-toml` renders nested tables when stringifying. For instance, the following object:

```js
{
  a: {
    b: [
      { b: 1, c: 2 },
    ],
  },
}
```

is rendered by `smol-toml` as

```toml
[a]
[[a.b]]
b = 1
c = 2
```

and by `@iarna/toml` as

```toml
[[a.b]]
b = 1
c = 2
```

Both are valid, but the `@iarna/toml` output seems clearer and easier to work with. As such, this PR modifies the `smol-toml` stringify logic to not render a table key if:
1. The table has children
2. All children are themselves arrays or tables

- [x] I've added tests
- [x] I've run the TOML test suite, which passed