### PR TITLE
Deprecate default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ console.log(toml)
 
 Alternatively, if you prefer something similar to the JSON global, you can import the library as follows
 ```js
-import TOML from 'smol-toml'
+import * as TOML from 'smol-toml'
 
 TOML.stringify({ ... })
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,10 @@ import { TomlDate } from './date.js'
 import { TomlError } from './error.js'
 
 export type { TomlValue, TomlTable, TomlValueWithoutBigInt, TomlTableWithoutBigInt } from './util.js'
-export default { parse, stringify, TomlDate, TomlError }
 export { parse, stringify, TomlDate, TomlError }
 
+/** @deprecated import * as TOML from "smol-toml" */
+export default { parse, stringify, TomlDate, TomlError }
 export type {
 	/** @deprecated use TomlValue instead */
 	TomlValue as TomlPrimitive


### PR DESCRIPTION
I think this use is not what `default` is made for, and that this feature (of importing everything in an object) is better covered by the [native MJS syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#namespace_import) of `import * as`.

Benefits of that syntax: the "namespace object" is sealed, and has a null protoype, which is not the case of the literal object I'm deprecating here.
Also, removing the default export (which can be done in the next major version) removes the "default" key from the namespace object.