### PR TITLE
fix(stringify): emit integer-valued numbers beyond the safe-integer range as floats

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -61,6 +61,10 @@ function stringifyValue (val: any, type: ExtendedType, depth: number, numberAsFl
 		if (val === Infinity) return 'inf'
 		if (val === -Infinity) return '-inf'
 		if (numberAsFloat && Number.isInteger(val)) return val.toFixed(1)
+		// An integer-valued number beyond the safe-integer range would serialize as
+		// a bare integer literal that the parser rejects (an integer must be exactly
+		// representable). Emit it in float notation so it round-trips as a float.
+		if (Number.isInteger(val) && !Number.isSafeInteger(val)) return val.toExponential()
 		return val.toString()
 	}
 

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -28,6 +28,7 @@
 
 import { expect, it } from 'vitest'
 import { stringify } from '../src/stringify.js'
+import { parse } from '../src/parse.js'
 import { TomlDate } from '../src/date.js'
 
 it('stringifies a basic object', () => {
@@ -89,6 +90,15 @@ nan = nan
 
 	expect(stringify(obj)).toBe(expected)
 	expect(stringify(obj, { numbersAsFloat: true })).toBe(expected)
+})
+
+it('stringifies integer-valued numbers outside the safe-integer range so they round-trip', () => {
+	// These are integer-valued floats; emitting them as bare integer literals
+	// produces tokens the parser rejects (an integer must be exactly
+	// representable), so they must be serialized in float notation.
+	for (const n of [ 1e16, 2 ** 53, -(2 ** 53), 123456789012345680000 ]) {
+		expect(parse(stringify({ a: n })).a).toBe(n)
+	}
 })
 
 it('stringifies dates properly', () => {


### PR DESCRIPTION
### Problem

`stringify` can produce output its own `parse` rejects, so the library fails to round-trip its own serialization:

```js
import { parse, stringify } from 'smol-toml'

parse(stringify({ a: 1e16 }))
// Uncaught: Invalid TOML document: integer value cannot be represented losslessly
//   a = 10000000000000000
```

### Cause

An integer-valued `number` is serialized as a bare integer literal (`val.toString()`). For magnitudes `>= 2^53` (and `< 1e21`, where `toString()` still emits plain digits rather than exponent form) the emitted token is an integer literal that the parser then rejects — integers must be exactly representable, and these are not. The threshold is exactly `Number.MAX_SAFE_INTEGER`: `2^53 - 1` round-trips, `2^53` throws.

This affects every integer-valued `number` in `[2^53, 1e21)`, e.g. `1e16`, `2 ** 53`, `123456789012345680000`.

### Fix

These values are floats, so emit them in float notation (`toExponential()`) when the integer is outside the safe-integer range. Safe integers keep their integer form, so the existing "preserve int-ness" behaviour for normal integer-valued floats is unchanged.

```js
parse(stringify({ a: 1e16 })).a            // 1e16   (emits `a = 1e+16`)
parse(stringify({ a: 2 ** 53 })).a         // 9007199254740992
parse(stringify({ a: 9007199254740991 })).a // unchanged: `a = 9007199254740991`
```

### Tests

Added a round-trip test over `[1e16, 2 ** 53, -(2 ** 53), 123456789012345680000]` in `test/stringify.test.ts` (red before, green after). Full suite green (142 passed). Build/typecheck clean.