### PR TITLE
fix(date): reject out-of-range calendar dates

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -33,6 +33,15 @@ type Offset = string | null
 
 let DATE_TIME_RE = /^(\d{4}-\d{2}-\d{2})?[T ]?(?:(\d{2}):\d{2}(?::\d{2}(?:\.\d+)?)?)?(Z|[-+]\d{2}:\d{2})?$/i
 
+function isValidCalendarDay (ymd: string) {
+	let year = +ymd.slice(0, 4)
+	let month = +ymd.slice(5, 7)
+	let day = +ymd.slice(8, 10)
+	let leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+	let max = month === 2 ? (leap ? 29 : 28) : month === 4 || month === 6 || month === 9 || month === 11 ? 30 : 31
+	return month >= 1 && month <= 12 && day >= 1 && day <= max
+}
+
 export class TomlDate extends Date {
 	#hasDate = false
 	#hasTime = false
@@ -54,8 +63,8 @@ export class TomlDate extends Date {
 				hasTime = !!match[2]
 				// Make sure to use T instead of a space. Breaks in case of extreme values otherwise.
 				hasTime && date[10] === ' ' && (date = date.replace(' ', 'T'))
-				// Do not allow rollover hours.
-				if (match[2] && +match[2] > 23) {
+				// Do not allow rollover hours or invalid calendar days.
+				if ((match[2] && +match[2] > 23) || (match[1] && !isValidCalendarDay(match[1]))) {
 					date = ''
 				} else {
 					offset = match[3] || null

--- a/test/date.test.ts
+++ b/test/date.test.ts
@@ -36,6 +36,25 @@ it('does properly handle date offsets', () => {
 	expect(new TomlDate('1979-05-27T07:32:00-08:00')).not.toEqual(new Date('1979-05-27T07:32:00-07:00'))
 })
 
+it('rejects out-of-range calendar dates', () => {
+	expect(new TomlDate('2100-02-29').isValid()).toBe(false) // Feb 29 in a non-leap year
+	expect(new TomlDate('1988-02-30').isValid()).toBe(false)
+	expect(new TomlDate('2021-04-31').isValid()).toBe(false) // April has 30 days
+	expect(new TomlDate('2021-06-31').isValid()).toBe(false)
+	expect(new TomlDate('2021-09-31').isValid()).toBe(false)
+	expect(new TomlDate('2021-11-31').isValid()).toBe(false)
+})
+
+it('accepts in-range calendar dates including leap days', () => {
+	expect(new TomlDate('2000-02-29').isValid()).toBe(true) // leap year (divisible by 400)
+	expect(new TomlDate('2024-02-29').isValid()).toBe(true)
+	expect(new TomlDate('2021-02-28').isValid()).toBe(true)
+	expect(new TomlDate('2021-04-30').isValid()).toBe(true)
+	expect(new TomlDate('2021-12-31').isValid()).toBe(true)
+	// an offset datetime whose UTC day differs from the local day must stay valid
+	expect(new TomlDate('2021-01-01T00:00:00+10:00').isValid()).toBe(true)
+})
+
 it('handles extreme datetimes', () => {
 	expect(new TomlDate('0001-01-01 00:00:00Z').toISOString()).toBe('0001-01-01T00:00:00.000Z')
 	expect(new TomlDate('0001-01-01 00:00:00').toISOString()).toBe('0001-01-01T00:00:00.000')


### PR DESCRIPTION
### Problem

Out-of-range calendar dates are accepted and silently rolled over to the next valid date:

```js
parse('d = 2100-02-29').d.toISOString() // "2100-03-01" (Feb 29 in a non-leap year)
parse('d = 1988-02-30').d.toISOString() // "1988-03-01"
parse('d = 2021-04-31').d.toISOString() // "2021-05-01" (April has 30 days)
```

These are checked against the official [`toml-test`](https://github.com/toml-lang/toml-test) suite cases `invalid/local-date/feb-29`, `invalid/local-date/feb-30`, and the `datetime`/`local-datetime` variants (present in both the 1.0.0 and 1.1.0 manifests).

### Cause

In `TomlDate`, the only validation is `isNaN(this.getTime())`. That catches grossly invalid values (month 13, day 32 → `Invalid Date`), but a JS `Date` silently *normalizes* an in-range-but-invalid day (Feb 29 in a non-leap year, Feb 30, the 31st of a 30-day month), so those pass the `isNaN` check and are returned as a different date. TOML 1.0/1.1 require a valid RFC 3339 full-date, so they must be rejected.

### Fix

Validate the day against the month and leap year, mirroring the existing "rollover hours" guard. The check uses the parsed wall-clock digits (`match[1]`), not the UTC-shifted `Date`, so an offset datetime whose UTC day differs from the local day (e.g. `2021-01-01T00:00:00+10:00`) stays valid.

### Verification

- New tests in `test/date.test.ts` covering invalid days (incl. non-leap Feb 29) and valid leap days (`2000-02-29`, `2024-02-29`) + the offset-datetime edge; they fail before, pass after.
- Full suite: **143 passing**, no regressions.
- Differential vs an independent UTC-`setUTCFullYear` oracle over 40,000 random `Y-M-D`: **0 divergences** (the parser rejects exactly the calendar-invalid dates).
