### PR TITLE
fix: reject lone surrogates in stringify instead of emitting invalid TOML

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -28,6 +28,12 @@
 
 let BARE_KEY = /^[a-z0-9-_]+$/i
 
+// A lone surrogate (a high surrogate not followed by a low one, or a low
+// surrogate not preceded by a high one) is not a valid Unicode scalar value and
+// cannot be represented in a TOML document: JSON.stringify emits it as a \uXXXX
+// escape, which the parser then rejects as an invalid unicode escape.
+let LONE_SURROGATE = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/
+
 type ExtendedType = ReturnType<typeof extendedTypeOf>
 function extendedTypeOf(obj: any) {
 	let type = typeof obj
@@ -48,6 +54,10 @@ function isArrayOfTables(obj: any[]) {
 }
 
 function formatString(s: string) {
+	if (LONE_SURROGATE.test(s)) {
+		throw new TypeError('cannot serialize a string containing lone surrogates')
+	}
+
 	return JSON.stringify(s).replace(/\x7f/g, '\\u007f')
 }
 

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -391,3 +391,15 @@ it('rejects functions and symbols', () => {
 it('rejects invalid dates', () => {
 	expect(() => stringify({ a: new Date('Invalid Date') })).toThrow(TypeError)
 })
+
+it('rejects strings containing lone surrogates', () => {
+	// JSON.stringify emits a lone surrogate as a \uXXXX escape, which is not a
+	// valid Unicode scalar value and which the parser rejects, so stringifying
+	// one would otherwise produce a document that cannot be parsed back.
+	expect(() => stringify({ a: '\ud800' })).toThrow(TypeError)
+	expect(() => stringify({ a: 'a\udfffb' })).toThrow(TypeError)
+	expect(() => stringify({ '\ud834': 'a' })).toThrow(TypeError)
+
+	// A valid surrogate pair is a scalar value and must still be serialized.
+	expect(() => stringify({ a: '𝄞' })).not.toThrow()
+})


### PR DESCRIPTION
`stringify` builds basic strings with `JSON.stringify`, which escapes a lone surrogate (an unpaired `\uD800`-`\uDFFF` code unit) as a `\uXXXX` sequence. TOML only allows `\u`/`\U` escapes for valid Unicode scalar values, and the parser rejects surrogate code points (`src/primitive.ts`):

```ts
if (value < 0 || value > 0x10ffff || (value >= 0xd800 && value <= 0xdfff)) {
    throw new TomlError('invalid unicode escape', { toml: str, ptr: i })
}
```

So `stringify` can emit a document that its own `parse` cannot read:

```js
import { parse, stringify } from 'smol-toml'

const toml = stringify({ a: '\ud800' }) // 'a = "\ud800"\n'
parse(toml)                             // TomlError: invalid unicode escape
```

A lone surrogate has no representation in a TOML document, so this is the same category as the values `stringify` already refuses (invalid dates, symbols, functions, `null`/`undefined` in arrays). This makes `formatString` throw a `TypeError` for lone surrogates rather than producing output that round-trips into a parse error. The guard lives in `formatString`, so it covers both string values and quoted keys. Valid surrogate pairs such as `𝄞` are scalar values and are still serialized.

Added a test next to the existing `rejects ...` cases. `pnpm test` is green.
