### PR TITLE
fix: preserve negative zero sign when stringifying floats

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -60,6 +60,7 @@ function stringifyValue(val: any, type: ExtendedType, depth: number, numberAsFlo
 		if (isNaN(val)) return 'nan'
 		if (val === Infinity) return 'inf'
 		if (val === -Infinity) return '-inf'
+		if (Object.is(val, -0)) return '-0.0'
 		if (Number.isInteger(val) && (numberAsFloat || !Number.isSafeInteger(val))) return val.toFixed(1)
 		return val.toString()
 	}

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -99,6 +99,15 @@ nan = nan
 	expect(stringify(obj, { numbersAsFloat: true })).toBe(expected)
 })
 
+it('stringifies negative zero as a float, preserving the sign', () => {
+	const expected = `
+a = -0.0
+`.trimStart()
+
+	expect(stringify({ a: -0 })).toBe(expected)
+	expect(stringify({ a: -0 }, { numbersAsFloat: true })).toBe(expected)
+})
+
 it('stringifies dates properly', () => {
 	const expected = `
 date1 = 1979-05-27T07:32:00.000-08:00


### PR DESCRIPTION
## Summary
`stringify()` silently flips `-0.0` to `0` on round-trip: `stringify(parse('a = -0.0'))` produces `a = 0`. The number branch in `stringifyValue()` relies on `Number.toString()`/`toFixed()`, neither of which renders a sign for JS `-0`.

The parser already treats this as intentional (`test/value.test.ts:146`, and confirmed in #30: "smol preserves correctly (-0.0 != 0.0)" during deserialization) — stringify should preserve the same guarantee on the way back out.

Since integer `-0` is already normalized to `+0` at parse time (no such thing as a negative-zero TOML integer, also per #30), any JS `-0` reaching `stringifyValue` can only have come from a float, so it's always safe to emit `-0.0` regardless of the `numbersAsFloat` option.

## Changes
- `src/stringify.ts`: special-case `Object.is(val, -0)` before the integer/float branch, returning `'-0.0'`.
- `test/stringify.test.ts`: add a test alongside the existing special-float-value cases.

## Testing
- Added test passes; full suite: 217/217 passing.
- `tsc --noEmit` clean.
- Manually verified before/after: `stringify({a: -0})` was `"a = 0\n"`, now `"a = -0.0\n"`, and `parse(stringify({a:-0})).a` round-trips to `-0` (`Object.is` true).