### PR TITLE
fix(parse): require both closing brackets on an array-of-tables header

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -147,10 +147,12 @@ export function parse(toml: string, { maxDepth = 1000, integersAsBigInt }: Parse
 
 			let k = parseKey(ctx, ']')
 			if (isTableArray) {
-				if (toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */) {
+				// `ctx.p - 1` rejects anything between the two brackets (parseKey
+				// skips trailing whitespace), `ctx.p` requires the second one.
+				if (toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */ || toml.charCodeAt(ctx.p) !== 0x5d /* ] */) {
 					throw new TomlError('expected end of table declaration', {
 						toml: toml,
-						ptr: ctx.p - 1,
+						ptr: ctx.p,
 					})
 				}
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -210,6 +210,13 @@ it('rejects invalid arrays of table', () => {
 	expect(() => parse('[[uwu] ]')).toThrow(TomlError)
 })
 
+it('rejects an array of tables header closed by a single bracket', () => {
+	expect(() => parse('[[uwu]')).toThrow(TomlError)
+	expect(() => parse('[[uwu]x')).toThrow(TomlError)
+	expect(() => parse('[[uwu]\nowo = 1')).toThrow(TomlError)
+	expect(() => parse('[[uwu] ')).toThrow(TomlError)
+})
+
 it('parses arrays of tables with subtables', () => {
 	const doc = `
 [[fruits]]


### PR DESCRIPTION
Fixes #65.

## Problem

An array-of-tables header closed by a single `]` is accepted when it is the last thing in the document, and one trailing character is silently discarded:

```js
parse('[[a]')   // => { a: [ {} ] }   expected: throw
parse('[[a]x')  // => { a: [ {} ] }   expected: throw ('x' is dropped)
```

TOML 1.1.0 requires `array-table-close = ws %x5D.5D`, so `[[a]` cannot derive from `array-table`. BurntSushi/toml, CPython `tomllib` and Rust `toml` all reject it.

## Cause

```js
let k = parseKey(ctx, ']')      // consumes through the first ']'
if (isTableArray) {
    if (toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */) { throw ... }
    ctx.p++
}
```

`ctx.p - 1` is the `]` that `parseKey` has already consumed, so the comparison is always true and the guard can never fire. The second bracket is never required, and `ctx.p++` advances past whatever happens to be there. That accounts for the whole table: at EOF the increment is a no-op (`[[a]`), with exactly one trailing character it swallows it (`[[a]x`), and with more the leftovers produce an unrelated error (`[[a]xyz`).

## Fix

The old comparison is not dead weight — `parseKey` calls `skipVoid(ctx, true, true)` after the key, so `ctx.p - 1` is what rejects tokens between the two brackets (`[[uwu] ]`, covered by an existing test). The new condition keeps it and adds the missing requirement that `ctx.p` is the second bracket:

```js
if (toml.charCodeAt(ctx.p - 1) !== 0x5d || toml.charCodeAt(ctx.p) !== 0x5d) {
```

`charCodeAt` past the end returns `NaN`, so EOF fails the check without a separate length test. The error pointer moves from `ctx.p - 1` (the consumed bracket) to `ctx.p` (where the missing one should be).

## Validation

- Existing suite: **141 passed, 1 skipped**, no changes to the existing expectations.
- Added a case next to `rejects invalid arrays of table` covering `[[uwu]`, `[[uwu]x`, `[[uwu] ` and `[[uwu]\nowo = 1`.
- `toml-test` 1.1.0 with the skips from `run-toml-test.bash`: **690 → 692** passing. The two newly passing cases are `invalid/table/array-no-close-05` (`[[a]`) and `-06` (`[[a]x`), which landed in toml-test via toml-lang/toml-test#205. The remaining failures (`linetab-number-01..04`, `integer/long`, `utf8-bom-01/02`) are pre-existing and untouched.
- Positive cases still parse: `[[a]]`, `[[ a ]]`, `[[a.b]]`, `[[a]] # c`, `[[a]]\n[[a]]`, CRLF variants.

## Cost

One extra `charCodeAt` on the array-of-tables header path only — not on key-value lines, values, or plain `[table]` headers.
