### PR TITLE
fix: require both closing brackets for array-table headers

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -147,10 +147,15 @@ export function parse(toml: string, { maxDepth = 1000, integersAsBigInt }: Parse
 
 			let k = parseKey(ctx, ']')
 			if (isTableArray) {
-				if (toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */) {
+				// The two brackets of `]]` must be adjacent: `parseKey` already stopped
+				// right after the first one, so the current char must be the second
+				// one and the previous char must still be the first one (if any
+				// whitespace was in between, `parseKey`'s trailing skipVoid would have
+				// walked past it, moving the previous char off the first bracket).
+				if (toml.charCodeAt(ctx.p) !== 0x5d /* ] */ || toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */) {
 					throw new TomlError('expected end of table declaration', {
 						toml: toml,
-						ptr: ctx.p - 1,
+						ptr: ctx.p,
 					})
 				}
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -210,6 +210,19 @@ it('rejects invalid arrays of table', () => {
 	expect(() => parse('[[uwu] ]')).toThrow(TomlError)
 })
 
+it('rejects an array-table header closed by a single bracket at the end of the document', () => {
+	// A single trailing `]` after `[[a` is not a valid `array-table-close` (which
+	// requires two adjacent brackets), even when it happens to be the last thing
+	// in the document.
+	expect(() => parse('[[a]')).toThrow(TomlError)
+})
+
+it('rejects an array-table header closed by a single bracket followed by extra content', () => {
+	// The parser used to silently swallow the one character following a lone `]`
+	// here instead of noticing the second bracket was missing.
+	expect(() => parse('[[a]x')).toThrow(TomlError)
+})
+
 it('parses arrays of tables with subtables', () => {
 	const doc = `
 [[fruits]]


### PR DESCRIPTION
`parse('[[a]')` currently returns `{ a: [ {} ] }` instead of throwing. So does `parse('[[a]x')`, except the `x` is silently dropped.

Per the grammar, `array-table-close` is `ws %x5D.5D`, i.e. two adjacent closing brackets. The guard for this in `parse.ts` is:

```js
let k = parseKey(ctx, ']')
if (isTableArray) {
    if (toml.charCodeAt(ctx.p - 1) !== 0x5d /* ] */) {
        throw new TomlError('expected end of table declaration', { ... })
    }
    ctx.p++
}
```

`parseKey(ctx, ']')` stops right after consuming the first `]` as its own terminator, so `ctx.p - 1` is always that same `]` it just consumed. The condition can never be false, and the "second bracket" check never actually looks at the second bracket:

- With nothing left in the document, `ctx.p++` is a no-op, so `[[a]` parses as if it were `[[a]]`.
- With one character left, that character gets skipped over the same way, so `[[a]x` parses the same as `[[a]]` and silently drops the `x`.
- With more than one character left, the leftover content trips a later, unrelated check, which is why `[[a]xyz` already raised before this fix.

I checked a few other implementations and they all reject a lone `]` here (Go's BurntSushi/toml, Python's tomllib, Rust's toml crate).

This fixes the check to look at the actual second bracket (`ctx.p`) and also confirm the char before it is still the first bracket (`ctx.p - 1`), so a whitespace-separated `] ]` (which the trailing `skipVoid` inside `parseKey` would otherwise walk past) is still rejected the same way the existing `rejects invalid arrays of table` test expects for `[[uwu] ]`.

Added two regression tests for the EOF and trailing-character cases. Ran the full existing suite locally (`vitest run`), 140 passing, none broken by this change.